### PR TITLE
gtk3対応

### DIFF
--- a/.mikutter.yml
+++ b/.mikutter.yml
@@ -6,7 +6,7 @@ depends:
   - list
   - settings
   - gui
-  - gtk
+  - gtk3
   - uitranslator
   - skin
 version: '1.0'

--- a/list_settings.rb
+++ b/list_settings.rb
@@ -21,7 +21,7 @@ Plugin.create :list_settings do
       iter[Plugin::ListSettings::Tab::NAME] = list[:name]
       iter[Plugin::ListSettings::Tab::DESCRIPTION] = list[:description]
       iter[Plugin::ListSettings::Tab::PUBLICITY] = list[:mode] }
-    Gtk::HBox.new.add(tab).closeup(tab.buttons(Gtk::VBox)).show_all end
+    Gtk::Box.new(:horizontal).add(tab).pack_start(tab.buttons(Gtk::Box), expand: false).show_all end
 
   # フォローしているリストを返す
   def available_lists

--- a/list_settings.rb
+++ b/list_settings.rb
@@ -8,7 +8,7 @@ Plugin.create :list_settings do
   this = self
 
   settings _("リスト") do
-    pack_start(this.setting_container, true)
+    add(this.setting_container)
   end
 
   # 設定のGtkウィジェット

--- a/list_settings.rb
+++ b/list_settings.rb
@@ -2,7 +2,7 @@
 
 require_relative 'tab'
 
-require 'gtk2'
+require 'gtk3'
 
 Plugin.create :list_settings do
   this = self

--- a/tab.rb
+++ b/tab.rb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-require 'gtk2'
+require 'gtk3'
 require_relative 'listlist'
 
 # 設定画面のCRUD

--- a/tab.rb
+++ b/tab.rb
@@ -30,7 +30,7 @@ module Plugin::ListSettings
     end
 
     def buttons(box_klass)
-      box_klass.new(false, 4).closeup(create_button).closeup(update_button).closeup(delete_button).closeup(extract_button) end
+      box_klass.new(:vertical, 4).pack_start(create_button, expand: false).pack_start(update_button, expand: false).pack_start(delete_button, extract: false).pack_start(extract_button, expand: false) end
 
     def menu_pop(widget, event)
       _p = Plugin[:list_settings]
@@ -43,7 +43,7 @@ module Plugin::ListSettings
 
     def extract_button
       if not defined? @extract_button
-        @extract_button = Gtk::Button.new(Plugin[:list_settings]._("タブを作成"))
+        @extract_button = Gtk::Button.new(label: Plugin[:list_settings]._("タブを作成"))
         @extract_button.ssc(:clicked) {
           record_extract(nil, nil) } end
       @extract_button end
@@ -107,8 +107,8 @@ module Plugin::ListSettings
         prompt = Gtk::Entry.new
         prompt.text = list[:name]
         dialog.vbox.
-          add(Gtk::HBox.new(false, 8).
-               closeup(Gtk::Label.new(Plugin[:list_settings]._("タブの名前"))).
+          add(Gtk::Box.new(:horizontal, 8).
+               pack_start(Gtk::Label.new(Plugin[:list_settings]._("タブの名前")), expand: false).
                add(prompt).show_all)
         dialog.run{ |response|
           if Gtk::Dialog::RESPONSE_ACCEPT == response


### PR DESCRIPTION
とりあえず手元で動いているgtk3差分です。
が、 mikutter本体の https://dev.mikutter.hachune.net/issues/1380 の
Gtk::CRUD 依存も直さないと設定自体は動かないようです。