### PR TITLE
タブの作成を動くようにする

### DIFF
--- a/list_settings.rb
+++ b/list_settings.rb
@@ -14,6 +14,8 @@ Plugin.create :list_settings do
   # 設定のGtkウィジェット
   def setting_container
     tab = Plugin::ListSettings::Tab.new(self)
+    tab.hexpand = true
+    tab.vexpand = true
     available_lists.each{ |list|
       iter = tab.model.append
       iter[Plugin::ListSettings::Tab::SLUG] = list[:full_name]

--- a/tab.rb
+++ b/tab.rb
@@ -49,7 +49,7 @@ module Plugin::ListSettings
       @extract_button end
 
     def record_extract(optional, widget)
-      self.selection.selected_each {|model, path, iter|
+      self.selection.each {|model, path, iter|
         on_extract(iter) } end
 
     def on_created(iter)
@@ -98,15 +98,17 @@ module Plugin::ListSettings
     def on_extract(iter)
       list = iter[LIST]
       if list
-        dialog = Gtk::Dialog.new(Plugin[:list_settings]._("リスト「%{list_name}」の抽出タブを作成 - %{mikutter}") % {
+        dialog = Gtk::Dialog.new(title: Plugin[:list_settings]._("リスト「%{list_name}」の抽出タブを作成 - %{mikutter}") % {
                                    mikutter: Environment::NAME,
                                    list_name: list[:name]
-                                 }, nil, nil,
-                                 [Gtk::Stock::OK, Gtk::Dialog::RESPONSE_ACCEPT],
-                                 [Gtk::Stock::CANCEL, Gtk::Dialog::RESPONSE_REJECT])
+                                 },
+                                 buttons: [
+                                   [Gtk::Stock::OK, Gtk::ResponseType::OK],
+                                   [Gtk::Stock::CANCEL, Gtk::ResponseType::CANCEL]
+                                 ])
         prompt = Gtk::Entry.new
         prompt.text = list[:name]
-        dialog.vbox.
+        dialog.child.
           add(Gtk::Box.new(:horizontal, 8).
                pack_start(Gtk::Label.new(Plugin[:list_settings]._("タブの名前")), expand: false).
                add(prompt).show_all)

--- a/tab.rb
+++ b/tab.rb
@@ -112,14 +112,20 @@ module Plugin::ListSettings
           add(Gtk::Box.new(:horizontal, 8).
                pack_start(Gtk::Label.new(Plugin[:list_settings]._("タブの名前")), expand: false).
                add(prompt).show_all)
-        dialog.run{ |response|
-          if Gtk::Dialog::RESPONSE_ACCEPT == response
+        dialog.signal_connect("response"){ |widget, response|
+          if response == Gtk::ResponseType::OK
             Plugin.call :extract_tab_create,
                         name: prompt.text,
                         icon: Skin.get_path('list.png'),
                         sources: [:"#{list.user.idname}_list_#{list[:id]}"] end
           dialog.destroy
-          prompt = dialog = nil } end
+          prompt = dialog = nil
+        }
+        dialog.signal_connect("destroy") {
+          false
+        }
+        dialog.show_all
+      end
     end
 
   end


### PR DESCRIPTION
ログの通り以下の修正を修正するブランチです。バラしたほうが良い、とかあればコメントお願いします。
各コミットの検討内容はそれぞれの issue コメントに記載しています。
* #6 は別プルリクエスト（別ブランチ）のほうがいいかもしれませんが、そもそも GTK3対応で必要だった分なので
* #2 のボタンレスポンス定義の修正が #5 と連動しています